### PR TITLE
Add pruning functionality

### DIFF
--- a/include/bonxai/bonxai.hpp
+++ b/include/bonxai/bonxai.hpp
@@ -142,6 +142,16 @@ public:
   template <class VisitorFunction>
   void forEachCell(VisitorFunction func);
 
+  /**
+   *  @brief pruneRoot apply a function of type:
+   *
+   *      void(const CoordT&)
+   *
+   * and prunes the root with that coordinate.
+   */
+  template <class VisitorFunction>
+  void pruneRoot(VisitorFunction func);
+
   /** Class to be used to set and get values of a cell of the Grid.
    *  It uses caching to speed up computation.
    *
@@ -536,6 +546,24 @@ inline void VoxelGrid<DataT>::forEachCell(VisitorFunction func)
         // apply the visitor
         func(leaf_grid->data[leaf_index], pos);
       }
+    }
+  }
+}
+
+//----------------------------------
+template <typename DataT>
+template <class VisitorFunction>
+inline void VoxelGrid<DataT>::pruneRoot(VisitorFunction func)
+{
+  for (auto it = root_map.begin(); it != root_map.end();)
+  {
+    if (func(it->first)) // if the coordinate satisfy condition checked by `func`
+    {
+      it = root_map.erase(it);
+    }
+    else
+    {
+      ++it;
     }
   }
 }


### PR DESCRIPTION
I added a functionality to allow users to prune a voxel grid. I find this necessary; an example use case would be pruning a voxel grid that stores point cloud data after accumulating it for some time. This will heavily improve efficiency and save resources.