### PR TITLE
Remove check for nullptr in dtor

### DIFF
--- a/bonxai_core/include/bonxai/bonxai.hpp
+++ b/bonxai_core/include/bonxai/bonxai.hpp
@@ -546,10 +546,7 @@ inline Grid<DataT>& Grid<DataT>::operator=(Grid&& other)
 template <typename DataT>
 inline Grid<DataT>::~Grid()
 {
-  if (data_)
-  {
-    delete[] data_;
-  }
+  delete[] data_;
 }
 
 template <typename DataT>


### PR DESCRIPTION
Technically, I think you can remove the `nullptr` check

https://en.cppreference.com/w/cpp/language/delete

> If expression evaluates to a null pointer value, no destructors are called, and the deallocation function may or may not be called (it's unspecified), but the default deallocation functions are guaranteed to do nothing when passed a null pointer.

(Obviously I know there's no detriment to having an explicit check in your dtor, but this seemed more fun that sending a slack message)