### PR TITLE
Fix: max_range_ used when inserting the pointcloud in bonxai

### DIFF
--- a/bonxai_ros/src/bonxai_server.cpp
+++ b/bonxai_ros/src/bonxai_server.cpp
@@ -196,9 +196,14 @@ void BonxaiServer::insertCloudCallback(const PointCloud2::ConstSharedPtr cloud)
   const auto& t = sensor_to_world_transform_stamped.transform.translation;
 
   const pcl::PointXYZ sensor_to_world_vec3(t.x, t.y, t.z);
+  if (max_range_ >= 0)
+  {
+    bonxai_->insertPointCloud(pc.points, sensor_to_world_vec3, max_range_);
+  } else
+  {
+    bonxai_->insertPointCloud(pc.points, sensor_to_world_vec3, std::numeric_limits<double>::infinity());
 
-  bonxai_->insertPointCloud(pc.points, sensor_to_world_vec3, max_range_);
-
+  }
   double total_elapsed = (rclcpp::Clock{}.now() - start_time).seconds();
   RCLCPP_DEBUG(
       get_logger(), "Pointcloud insertion in Bonxai done, %f sec)", total_elapsed);

--- a/bonxai_ros/src/bonxai_server.cpp
+++ b/bonxai_ros/src/bonxai_server.cpp
@@ -197,7 +197,7 @@ void BonxaiServer::insertCloudCallback(const PointCloud2::ConstSharedPtr cloud)
 
   const pcl::PointXYZ sensor_to_world_vec3(t.x, t.y, t.z);
 
-  bonxai_->insertPointCloud(pc.points, sensor_to_world_vec3, 30.0);
+  bonxai_->insertPointCloud(pc.points, sensor_to_world_vec3, max_range_);
 
   double total_elapsed = (rclcpp::Clock{}.now() - start_time).seconds();
   RCLCPP_DEBUG(


### PR DESCRIPTION
Quick fix that solves #25 . the `max_range` param was declared and set but not used in the function that inserts the incoming PointCloud into the bonxai.

Additionally, I realized that with this change, deactivating the `max_range` limiting setting it to -1 did not work, so I added a check for this case when inserting the PointCloud to the bonxai. If `max_range` is less than 0, then the max_range is infinity.