### PR TITLE
Fix prime number in hash function

### DIFF
--- a/bonxai_core/include/bonxai/grid_coord.hpp
+++ b/bonxai_core/include/bonxai/grid_coord.hpp
@@ -212,7 +212,7 @@ struct hash<Bonxai::CoordT> {
   std::size_t operator()(const Bonxai::CoordT& p) const {
     // same as OpenVDB
     return ((1 << 20) - 1) & (static_cast<int64_t>(p.x) * 73856093 ^  //
-                              static_cast<int64_t>(p.y) * 19349663 ^  //
+                              static_cast<int64_t>(p.y) * 19349669 ^  //
                               static_cast<int64_t>(p.z) * 83492791);
   }
 };


### PR DESCRIPTION
`19349663` is NOT a prime number.

This is a long-lasting error we encountered in many repos, and my colleague Benedikt has already [fixed it in OpenVDB](https://github.com/AcademySoftwareFoundation/openvdb/pull/1626)

Open3D also has the "proper" [prime number](https://github.com/isl-org/Open3D/blob/9d0cfc86b7591035aa2e030f3cea7af2a4b80755/cpp/open3d/t/geometry/kernel/VoxelBlockGridCPU.cpp#L46)

But many others [have the "wrong" one](https://github.com/search?q=%2219349663%22+language%3AC%2B%2B&type=code&l=C%2B%2B)

In any case, this shouldn't make a big difference; it's just to be consistent and have a slightly better hashing function.