### PR TITLE
Const correctness in `VoxelGrid<Type>::releaseUnusedMemory()`

### DIFF
--- a/bonxai_core/include/bonxai/bonxai.hpp
+++ b/bonxai_core/include/bonxai/bonxai.hpp
@@ -367,7 +367,7 @@ inline size_t Grid<DataT>::memUsage() const {
 template <typename DataT>
 inline void VoxelGrid<DataT>::releaseUnusedMemory() {
   std::vector<CoordT> keys_to_delete;
-  for (const auto& [key, inner_grid] : root_map) {
+  for (auto& [key, inner_grid] : root_map) {
     for (auto inner_it = inner_grid.mask().beginOn(); inner_it; ++inner_it) {
       const int32_t inner_index = *inner_it;
       auto& leaf_grid = inner_grid.cell(inner_index);


### PR DESCRIPTION
When trying to use the `VoxelGrid<Type>::releaseUnusedMemory()`, I got a const correctness issue related to the type dispatching at line 370 of `bonxai.hpp`

``` cpp
<stuff>
for (const auto& [key, inner_grid] : root_map) { // <- line 370 (the root problem)
    for (auto inner_it = inner_grid.mask().beginOn(); inner_it; ++inner_it) {
      const int32_t inner_index = *inner_it;
      auto& leaf_grid = inner_grid.cell(inner_index);
      if (leaf_grid->mask().isOff()) {
        inner_grid.mask().setOff(inner_index); // <- THE PROBLEM
        leaf_grid.reset();
      }
<more stuff>
```
 In this context `inner_grid` is const while we are trying to set the corresponding `Mask` to `false`.
