### PR TITLE
Fix voxelization around axes

### DIFF
--- a/bonxai_core/include/bonxai/bonxai.hpp
+++ b/bonxai_core/include/bonxai/bonxai.hpp
@@ -404,9 +404,9 @@ inline VoxelGrid<DataT>::VoxelGrid(double voxel_size, uint8_t inner_bits, uint8_
 template <typename DataT>
 inline CoordT VoxelGrid<DataT>::posToCoord(double x, double y, double z) const {
   return {
-      static_cast<int32_t>(std::nearbyint(x * inv_resolution)),
-      static_cast<int32_t>(std::nearbyint(y * inv_resolution)),
-      static_cast<int32_t>(std::nearbyint(z * inv_resolution))};
+      static_cast<int32_t>(std::floor(x * inv_resolution)),
+      static_cast<int32_t>(std::floor(y * inv_resolution)),
+      static_cast<int32_t>(std::floor(z * inv_resolution))};
 }
 
 template <typename DataT>

--- a/bonxai_core/include/bonxai/grid_coord.hpp
+++ b/bonxai_core/include/bonxai/grid_coord.hpp
@@ -79,9 +79,9 @@ struct CoordT {
 
 [[nodiscard]] inline CoordT PosToCoord(const Point3D& point, double inv_resolution) {
   return {
-      static_cast<int32_t>(std::nearbyint(point.x * inv_resolution)),
-      static_cast<int32_t>(std::nearbyint(point.y * inv_resolution)),
-      static_cast<int32_t>(std::nearbyint(point.z * inv_resolution))};
+      static_cast<int32_t>(std::floor(point.x * inv_resolution)),
+      static_cast<int32_t>(std::floor(point.y * inv_resolution)),
+      static_cast<int32_t>(std::floor(point.z * inv_resolution))};
 }
 
 [[nodiscard]] inline Point3D CoordToPos(const CoordT& coord, double resolution) {


### PR DESCRIPTION
The current implementation uses `std::nearbyint` to convert the 3D points to `CoordT`. Unless the used rounding mode is modified throw [std::fesetround](https://en.cppreference.com/w/cpp/numeric/fenv/feround), this will result in points being associated with the same voxel they lie around the "0-line" of each axis. Visually, this will look like this:

### Current

![current](https://github.com/user-attachments/assets/c1e03013-9b84-4248-95ac-6759acd35be2)

### This PR

![floor](https://github.com/user-attachments/assets/58373784-39b5-4ea9-87f1-0a6e5c32cf0e)

I selected `std::floor` arbitrarily, as there is no particular reason to select it instead of `std::ceil` or change the rounding style.

CC: @benemer