### PR TITLE
Publish as octomap

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ if ( ament_cmake_FOUND )
     target_link_libraries(bonxai_server
       bonxai_map
       ${PCL_LIBRARIES}
+      ${octomap_LIBRARIES}
     )
 
     rclcpp_components_register_node(bonxai_server

--- a/bonxai_ros/include/bonxai_server.hpp
+++ b/bonxai_ros/include/bonxai_server.hpp
@@ -76,7 +76,7 @@ class BonxaiServer : public rclcpp::Node {
   std::string base_frame_id_;   // base of the robot for ground plane filtering
 
   bool latched_topics_;
-  bool octomap_;
+  bool octomap_topic_;
 
   double res_;
 

--- a/bonxai_ros/include/bonxai_server.hpp
+++ b/bonxai_ros/include/bonxai_server.hpp
@@ -20,6 +20,8 @@
 #include "pcl_conversions/pcl_conversions.h"
 #include "rclcpp/rclcpp.hpp"
 #include "sensor_msgs/msg/point_cloud2.hpp"
+#include "octomap_msgs/msg/octomap.hpp"
+#include "octomap_msgs/conversions.h"
 #include "std_msgs/msg/color_rgba.hpp"
 #include "std_srvs/srv/empty.hpp"
 #include "tf2_eigen/tf2_eigen.hpp"
@@ -28,9 +30,12 @@
 #include "tf2_ros/message_filter.h"
 #include "tf2_ros/transform_listener.h"
 
+#include <octomap/octomap.h>
+
 namespace bonxai_server {
 
 using sensor_msgs::msg::PointCloud2;
+using octomap_msgs::msg::Octomap;
 
 class BonxaiServer : public rclcpp::Node {
  public:
@@ -55,6 +60,7 @@ class BonxaiServer : public rclcpp::Node {
       const std::vector<rclcpp::Parameter>& parameters);
 
   rclcpp::Publisher<PointCloud2>::SharedPtr point_cloud_pub_;
+  rclcpp::Publisher<Octomap>::SharedPtr octomap_pub_;
   message_filters::Subscriber<PointCloud2> point_cloud_sub_;
   std::shared_ptr<tf2_ros::MessageFilter<PointCloud2>> tf_point_cloud_sub_;
   // rclcpp::Service<BBoxSrv>::SharedPtr clear_bbox_srv_;
@@ -70,6 +76,7 @@ class BonxaiServer : public rclcpp::Node {
   std::string base_frame_id_;   // base of the robot for ground plane filtering
 
   bool latched_topics_;
+  bool octomap_;
 
   double res_;
 

--- a/bonxai_ros/src/bonxai_server.cpp
+++ b/bonxai_ros/src/bonxai_server.cpp
@@ -114,8 +114,17 @@ BonxaiServer::BonxaiServer(const rclcpp::NodeOptions& node_options)
   }
 
   auto qos = latched_topics_ ? rclcpp::QoS{1}.transient_local() : rclcpp::QoS{1};
-  point_cloud_pub_ = create_publisher<PointCloud2>("bonxai_point_cloud_centers", qos);
-
+  
+  octomap_ = declare_parameter("publish_octomap", false);
+  if (octomap_) {
+    octomap_pub_ = create_publisher<Octomap>("bonxai_point_cloud_centers", qos);
+    RCLCPP_INFO(
+        get_logger(),
+        "Publishing map as octomap");
+  } else {
+    point_cloud_pub_ = create_publisher<PointCloud2>("bonxai_point_cloud_centers", qos);
+  }
+  
   tf2_buffer_ = std::make_shared<tf2_ros::Buffer>(get_clock());
   auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
       this->get_node_base_interface(), this->get_node_timers_interface());
@@ -216,28 +225,54 @@ void BonxaiServer::publishAll(const rclcpp::Time& rostime) {
     return;
   }
 
-  bool publish_point_cloud =
-      (latched_topics_ || point_cloud_pub_->get_subscription_count() +
-                                  point_cloud_pub_->get_intra_process_subscription_count() >
-                              0);
+  int subscription_count = octomap_ 
+    ? octomap_pub_->get_subscription_count() + octomap_pub_->get_intra_process_subscription_count()
+    : point_cloud_pub_->get_subscription_count() + point_cloud_pub_->get_intra_process_subscription_count();
 
-  // init pointcloud for occupied space:
+  bool publish_point_cloud =
+      (latched_topics_ || subscription_count > 0);
+
   if (publish_point_cloud) {
+    std::unique_ptr<octomap::OcTree> tree = nullptr;
     thread_local pcl::PointCloud<PCLPoint> pcl_cloud;
     pcl_cloud.clear();
 
+    if (octomap_) {
+        tree = std::make_unique<octomap::OcTree>(res_);
+    }
+
     for (const auto& voxel : bonxai_result) {
       if (voxel.z() >= occupancy_min_z_ && voxel.z() <= occupancy_max_z_) {
-        pcl_cloud.push_back(PCLPoint(voxel.x(), voxel.y(), voxel.z()));
+        if (octomap_) {
+          tree->updateNode(octomap::point3d(voxel.x(), voxel.y(), voxel.z()), true);
+        } else {
+          pcl_cloud.push_back(PCLPoint(voxel.x(), voxel.y(), voxel.z()));
+        }
       }
     }
-    PointCloud2 cloud;
-    pcl::toROSMsg(pcl_cloud, cloud);
 
-    cloud.header.frame_id = world_frame_id_;
-    cloud.header.stamp = rostime;
-    point_cloud_pub_->publish(cloud);
-    RCLCPP_WARN(get_logger(), "Published occupancy grid with %ld voxels", pcl_cloud.points.size());
+    // Publish OctoMap
+    if (octomap_ && tree) {
+      Octomap octomap_msg;
+      octomap_msg.header.frame_id = world_frame_id_;
+      octomap_msg.header.stamp = rostime;
+      octomap_msg.resolution = res_;
+      octomap_msgs::binaryMapToMsg(*tree, octomap_msg);
+
+      octomap_pub_->publish(octomap_msg);
+      RCLCPP_WARN(get_logger(), "Published OctoMap with %ld nodes", tree->size());
+    }
+
+    // Publish PointCloud2
+    else {
+      PointCloud2 cloud;
+      pcl::toROSMsg(pcl_cloud, cloud);
+
+      cloud.header.frame_id = world_frame_id_;
+      cloud.header.stamp = rostime;
+      point_cloud_pub_->publish(cloud);
+      RCLCPP_WARN(get_logger(), "Published occupancy grid with %ld voxels", pcl_cloud.points.size());
+    }
   }
 }
 

--- a/package.xml
+++ b/package.xml
@@ -14,6 +14,7 @@
   <depend>rclcpp_components</depend>
   <depend>pcl_conversions</depend>
   <depend>sensor_msgs</depend>
+  <depend>octomap_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_eigen</depend>
   <depend>tf2_geometry_msgs</depend>


### PR DESCRIPTION
This PR adds the functionality to publish the results of Bonxai mapping as an OctoMap. This is particularly useful for functionalities such as collision-free path planning with MoveIt, which requires the voxel grid to be represented as an OctoMap.

The feature can be enabled using the boolean parameter `octomap_topic_`. When enabled, the OctoMap representation is generated and published, facilitating seamless integration with planning systems like MoveIt that depend on this format.

Key updates:

Added support for publishing Bonxai mapping results as an OctoMap.
Controlled through a boolean parameter `octomap_topic_` for flexibility.
This enhancement improves compatibility and expands the use cases of Bonxai mapping by enabling support for systems requiring OctoMap representations.