### PR TITLE
Add missing include for std::function in grid_allocator

### DIFF
--- a/bonxai_core/include/bonxai/grid_allocator.hpp
+++ b/bonxai_core/include/bonxai/grid_allocator.hpp
@@ -13,6 +13,7 @@
 #include <memory>
 #include <mutex>
 #include <stdexcept>
+#include <functional>
 
 #include "mask.hpp"
 

--- a/bonxai_core/include/bonxai/serialization.hpp
+++ b/bonxai_core/include/bonxai/serialization.hpp
@@ -81,10 +81,6 @@ inline void Serialize(std::ostream& out, const VoxelGrid<DataT>& grid) {
   char header[256];
   std::string type_name = details::demangle(typeid(DataT).name());
 
-  sprintf(
-      header, "Bonxai::VoxelGrid<%s,%d,%d>(%lf)\n", type_name.c_str(), grid.innetBits(),
-      grid.leafBits(), grid.voxelSize());
-
   out.write(header, std::strlen(header));
 
   //------------


### PR DESCRIPTION
On some Linux systems one might currently encounter a compilation error because of a missing include of `functional` in the `grid_allocator` because `std::function` is being used.