### PR TITLE
Implement PassThrough filters for point cloud axis limits

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CONFIG_PATH ${CMAKE_MODULE_PATH}  "${CMAKE_CURRENT_LIST_DIR}/cmake")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CONFIG_PATH}")
 
-find_package(PCL QUIET COMPONENTS common io)
+find_package(PCL QUIET COMPONENTS common io filters)
 
 find_package(benchmark QUIET)
 find_package(octomap QUIET)

--- a/bonxai_ros/include/bonxai_server.hpp
+++ b/bonxai_ros/include/bonxai_server.hpp
@@ -81,6 +81,14 @@ class BonxaiServer : public rclcpp::Node {
   // octomap::OcTreeKey padded_min_key_;
   unsigned multires_2d_scale_;
   bool project_complete_map_;
+
+  double point_cloud_limit_min_;
+  double point_cloud_limit_max_;
+  pcl::PassThrough<PCLPoint> passthrough_filter_x_;
+  pcl::PassThrough<PCLPoint> passthrough_filter_y_;
+  pcl::PassThrough<PCLPoint> passthrough_filter_z_;
+
+
 };
 }  // namespace bonxai_server
 


### PR DESCRIPTION
Solves #35 by using a passthrough filter. The error mentioned in #35 occurs when point cloud contains `inf` values, which I face when I simulate 3D lidar in gazebo sim and directly provide it to bonxai to map.

- Set up PassThrough filters for x, y, and z axes of the point cloud.
- Applied the full range of possible values for each axis using maximum and minimum limits.
- Configured the filters to process the input point cloud and sequentially apply filtering along each axis.