### PR TITLE
fix typo: segementation -> segmentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CONFIG_PATH ${CMAKE_MODULE_PATH}  "${CMAKE_CURRENT_LIST_DIR}/cmake")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CONFIG_PATH}")
 
-find_package(PCL QUIET COMPONENTS common filters io segementation)
+find_package(PCL QUIET COMPONENTS common filters io segmentation)
 
 find_package(benchmark QUIET)
 find_package(octomap QUIET)


### PR DESCRIPTION
Small typo in the `CMakeLists.txt`