### PR TITLE
Remove pcl segmentation as it is not used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CONFIG_PATH ${CMAKE_MODULE_PATH}  "${CMAKE_CURRENT_LIST_DIR}/cmake")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CONFIG_PATH}")
 
-find_package(PCL QUIET COMPONENTS common filters io segementation)
+find_package(PCL QUIET COMPONENTS common filters io)
 
 find_package(benchmark QUIET)
 find_package(octomap QUIET)

--- a/bonxai_ros/include/bonxai_server.hpp
+++ b/bonxai_ros/include/bonxai_server.hpp
@@ -5,7 +5,6 @@
 #include <pcl/filters/extract_indices.h>
 #include <pcl/filters/passthrough.h>
 #include <pcl/io/pcd_io.h>
-#include <pcl/segmentation/sac_segmentation.h>
 
 #include <algorithm>
 #include <limits>

--- a/package.xml
+++ b/package.xml
@@ -23,7 +23,6 @@
   <depend>message_filters</depend>
   <depend>libpcl-common</depend>
   <depend>libpcl-io</depend>
-  <depend>libpcl-segmentation</depend>
   <depend>libpcl-filters</depend>
 
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
I was wondering why `bonxai_server` was still building even if a typo was present (#53). Then I realized that `#include <pcl/segmentation/sac_segmentation.h>` is never used as far as I could tell, so I removed it in this PR in case it is not needed anymore. Feel free to close this PR straightaway if this assumption is wrong!