### PR TITLE
Fix for Jazzy and Humble's QoS

### DIFF
--- a/bonxai_ros/include/bonxai_server.hpp
+++ b/bonxai_ros/include/bonxai_server.hpp
@@ -18,6 +18,7 @@
 #include "message_filters/subscriber.hpp"
 #include "pcl_conversions/pcl_conversions.h"
 #include "rclcpp/rclcpp.hpp"
+#include "rmw/qos_profiles.h"
 #include "sensor_msgs/msg/point_cloud2.hpp"
 #include "std_msgs/msg/color_rgba.hpp"
 #include "std_srvs/srv/empty.hpp"

--- a/bonxai_ros/src/bonxai_server.cpp
+++ b/bonxai_ros/src/bonxai_server.cpp
@@ -123,7 +123,7 @@ BonxaiServer::BonxaiServer(const rclcpp::NodeOptions& node_options)
   tf2_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf2_buffer_);
 
   using std::chrono_literals::operator""s;
-  point_cloud_sub_.subscribe(this, "cloud_in", rclcpp::SensorDataQoS());
+  point_cloud_sub_.subscribe(this, "cloud_in", rmw_qos_profile_sensor_data);
   tf_point_cloud_sub_ = std::make_shared<tf2_ros::MessageFilter<PointCloud2>>(
       point_cloud_sub_, *tf2_buffer_, world_frame_id_, 5, this->get_node_logging_interface(),
       this->get_node_clock_interface(), 5s);


### PR DESCRIPTION
I'm only changing the instantiation of the QoS so that the package compiles (and runs) for ROS2 Humble and Jazzy (tested on both).