### PR TITLE
Fix accessor null cache

### DIFF
--- a/bonxai_core/CMakeLists.txt
+++ b/bonxai_core/CMakeLists.txt
@@ -13,3 +13,8 @@ target_include_directories(bonxai_core PUBLIC INTERFACE
 if(benchmark_FOUND)
     add_subdirectory(benchmark)
 endif()
+
+find_package(GTest QUIET)
+if(GTest_FOUND)
+    add_subdirectory(test)
+endif()

--- a/bonxai_core/include/bonxai/bonxai.hpp
+++ b/bonxai_core/include/bonxai/bonxai.hpp
@@ -475,7 +475,7 @@ inline DataT* VoxelGrid<DataT>::Accessor::value(const CoordT& coord, bool create
 
   const CoordT inner_key = mutable_grid_.getInnerKey(coord);
 
-  if (inner_key != prev_inner_coord_) {
+  if (inner_key != prev_inner_coord_ || prev_leaf_ptr_ == nullptr) {
     prev_leaf_ptr_ = getLeafGrid(coord, create_if_missing);
     prev_inner_coord_ = inner_key;
   }
@@ -538,7 +538,7 @@ template <typename DataT>
 inline bool VoxelGrid<DataT>::Accessor::setCellOn(const CoordT& coord, const DataT& default_value) {
   const CoordT inner_key = mutable_grid_.getInnerKey(coord);
 
-  if (inner_key != prev_inner_coord_) {
+  if (inner_key != prev_inner_coord_ || prev_leaf_ptr_ == nullptr) {
     prev_leaf_ptr_ = getLeafGrid(coord, true);
     prev_inner_coord_ = inner_key;
   }

--- a/bonxai_core/test/CMakeLists.txt
+++ b/bonxai_core/test/CMakeLists.txt
@@ -1,0 +1,8 @@
+enable_testing()
+
+add_executable(voxel_grid_test voxel_grid_test.cpp)
+target_link_libraries(voxel_grid_test PRIVATE bonxai_core)
+
+target_link_libraries(voxel_grid_test PRIVATE GTest::gtest GTest::gtest_main)
+
+add_test(NAME voxel_grid_test COMMAND voxel_grid_test)

--- a/bonxai_core/test/voxel_grid_test.cpp
+++ b/bonxai_core/test/voxel_grid_test.cpp
@@ -1,0 +1,48 @@
+#include <gtest/gtest.h>
+#include "bonxai/bonxai.hpp"
+
+TEST(VoxelGridValueSegfaultTest, AccessWithNullPtrInitially) {
+  std::unique_ptr<Bonxai::VoxelGrid<int>> grid;
+  grid = std::make_unique<Bonxai::VoxelGrid<int>>(1.0);
+
+  auto accessor = grid->createAccessor();
+
+  Bonxai::CoordT coord{10, 10, 10};
+
+  // Cell doesn't exist, so we expect a nullptr.
+  int* ptr1 = accessor.value(coord, false);
+  EXPECT_EQ(ptr1, nullptr);
+
+  // prev_leaf_ptr_ is nullptr now.
+
+  Bonxai::CoordT coord2{11, 11, 11};
+  // Create if is missing should create the cell and return a valid pointer even if prev_leaf_ptr is currently null.
+  int* ptr2 = accessor.value(coord2, true);
+  ASSERT_NE(ptr2, nullptr);
+  *ptr2 = 555;
+}
+
+TEST(VoxelGridSetCellOnTest, SetCellOnSegfaultWithNullPtrInitially) {
+  std::unique_ptr<Bonxai::VoxelGrid<int>> grid;
+  grid = std::make_unique<Bonxai::VoxelGrid<int>>(1.0);
+  auto accessor = grid->createAccessor();
+
+  // Define two coordinates that share the same inner_key.
+  Bonxai::CoordT coord1{10, 10, 10};
+  Bonxai::CoordT coord2{11, 11, 11};
+
+  // Trigger a cache miss.
+  int* ptr1 = accessor.value(coord1, false);
+  EXPECT_EQ(ptr1, nullptr);
+
+  // Attempt to set a cell ON in the same inner grid.
+  int default_value = 777;
+  bool was_on = accessor.setCellOn(coord2, default_value);
+
+  // 5. Verify the state is now correct
+  EXPECT_FALSE(was_on);
+
+  int* ptr2 = accessor.value(coord2, false);
+  ASSERT_NE(ptr2, nullptr);
+  EXPECT_EQ(*ptr2, default_value);
+}


### PR DESCRIPTION
### Summary
This PR fixes a segmentation fault that occurs when writing to a `VoxelGrid` immediately after a read-only query in the same unallocated region.

### Root Cause
When performing a read-only query (e.g., `value(coord, false)`) on an empty region of the grid, the `Accessor` correctly updates `prev_inner_coord_` but caches a `nullptr` for `prev_leaf_ptr_`.

If a subsequent write operation (e.g., `setCellOn` or `value(coord, true)`) falls within that same `inner_key` region, the `Accessor` registers a false cache hit because `inner_key == prev_inner_coord_`. It then attempts to dereference the cached `nullptr` to modify the mask, resulting in a crash.

 ### The Fix
Added `|| prev_leaf_ptr_ == nullptr` to the cache validation conditions in both `value()` and `setCellOn()`.

This ensures that if the cache holds a null pointer, the `Accessor` is forced to call `getLeafGrid(coord, create_if_missing)` to safely allocate the missing leaf node before attempting to write to it.

### Testing
Added two new gtest cases:

- `VoxelGridValueSegfaultTest`: Verifies that `value(coord, true)` safely recovers and allocates a cell after a null cache.
- `VoxelGridSetCellOnTest`: Verifies that `setCellOn` safely allocates and sets a cell after a null cache.