### PR TITLE
Export Bonxai libraries as modern CMake targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,23 @@ if ( ament_cmake_FOUND )
       EXECUTABLE bonxai_server_node
     )
 
+    # bonxai_core/bonxai_map are plain CMake targets; export them so other ament
+    # packages in the workspace can link the probabilistic map
+    install(
+      TARGETS bonxai_core bonxai_map
+      EXPORT bonxai_ros_targets
+      ARCHIVE DESTINATION lib
+      LIBRARY DESTINATION lib
+      RUNTIME DESTINATION bin
+      INCLUDES DESTINATION include
+    )
+    install(
+      DIRECTORY bonxai_core/include/ bonxai_map/include/
+      DESTINATION include
+    )
+    ament_export_targets(bonxai_ros_targets HAS_LIBRARY_TARGET)
+    ament_export_dependencies(Eigen3 PCL)
+
     ament_auto_package(
       INSTALL_TO_SHARE
       bonxai_ros/launch


### PR DESCRIPTION
**MR Summary**

Modernize the Bonxai ROS CMake integration so downstream packages can consume Bonxai through exported CMake targets.

### Changes

- Install and export the `bonxai_core` and `bonxai_map` targets from the `bonxai_ros` package.
- Install the corresponding public headers.
- Export the targets with `ament_export_targets`.
- Export the required Eigen3 and PCL dependencies.
- Allow downstream consumer to link selectively against `bonxai_ros::bonxai_core` or `bonxai_ros::bonxai_map`.
- Remove the need for package-wide include-directory exports by relying on target usage requirements.

### Motivation

Previously, `bonxai_core` and `bonxai_map` were plain CMake targets that were unavailable to downstream ROS packages after installation. This change adopts modern target-based CMake usage, allowing consumers to use:

```cmake
find_package(bonxai_ros REQUIRED)
target_link_libraries(local_mapper PRIVATE bonxai_ros::bonxai_map)
```

This makes include paths and transitive dependencies part of the imported target and improves compatibility with isolated colcon builds.