### PR TITLE
Fix message_filters QoS compatibility with older ROS 2 distributions

### DIFF
--- a/bonxai_ros/src/bonxai_server.cpp
+++ b/bonxai_ros/src/bonxai_server.cpp
@@ -1,5 +1,7 @@
 #include "bonxai_server.hpp"
 
+#include <rclcpp/version.h>
+
 namespace {
 template <typename T>
 bool update_param(const std::vector<rclcpp::Parameter>& p, const std::string& name, T& value) {
@@ -123,7 +125,13 @@ BonxaiServer::BonxaiServer(const rclcpp::NodeOptions& node_options)
   tf2_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf2_buffer_);
 
   using std::chrono_literals::operator""s;
+#if RCLCPP_VERSION_GTE(29, 0, 0)
+  // Kilted, Rolling's message_filters::Subscriber allows to take an rclcpp::QoS directly.
   point_cloud_sub_.subscribe(this, "cloud_in", rclcpp::SensorDataQoS());
+#else
+  // Humble, Jazzy's message_filters::Subscriber takes an rmw_qos_profile_t, not an rclcpp::QoS.
+  point_cloud_sub_.subscribe(this, "cloud_in", rclcpp::SensorDataQoS().get_rmw_qos_profile());
+#endif
   tf_point_cloud_sub_ = std::make_shared<tf2_ros::MessageFilter<PointCloud2>>(
       point_cloud_sub_, *tf2_buffer_, world_frame_id_, 5, this->get_node_logging_interface(),
       this->get_node_clock_interface(), 5s);


### PR DESCRIPTION
replaces #58

## Summary

Add compatibility for the `message_filters::Subscriber::subscribe()` QoS API
used by older ROS 2 distributions such as Humble and Jazzy.

## Changes

- Pass `rclcpp::SensorDataQoS()` directly with `rclcpp >= 29`.
- Pass the underlying `rmw_qos_profile_t` with older `rclcpp` versions.
- Preserve sensor-data QoS behavior across supported ROS 2 distributions.

## Motivation

Older versions of `message_filters`, including the versions provided by ROS 2
Humble and Jazzy, do not accept `rclcpp::QoS` in `Subscriber::subscribe()`.
They require an `rmw_qos_profile_t`, obtained through
`get_rmw_qos_profile()`.

Without this compatibility branch, `bonxai_ros` fails to compile on those
distributions.

## Validation

- Built successfully on ROS 2 Jazzy with:
  - `rclcpp 28.1.21`
  - `message_filters 4.11.17`